### PR TITLE
Refactor: Optimize Active Service screens

### DIFF
--- a/app/src/main/java/com/example/engu_pension_verification_application/Constants/AppConstants.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/Constants/AppConstants.kt
@@ -1,0 +1,10 @@
+package com.example.engu_pension_verification_application.Constants
+
+object AppConstants {
+    const val BEARER = "Bearer"
+    const val SUCCESS = "success"
+    const val FAIL = "fail"
+    const val EXPIRED = "expired"
+    var ACCESS_TOKEN: String = ""
+    var REFRESH_TOKEN: String = ""
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/data/ApiResult.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/data/ApiResult.kt
@@ -1,0 +1,7 @@
+package com.example.engu_pension_verification_application.data
+
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class Error(val message: String) : ApiResult<Nothing>()
+//    object Loading : ApiResult<Nothing>()
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/data/NetworkRepo.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/data/NetworkRepo.kt
@@ -1,0 +1,66 @@
+package com.example.engu_pension_verification_application.data
+
+import android.util.Log
+import com.example.engu_pension_verification_application.Constants.AppConstants
+import com.example.engu_pension_verification_application.model.input.InputActiveBankInfo
+import com.example.engu_pension_verification_application.model.input.InputActiveBasicDetails
+import com.example.engu_pension_verification_application.model.input.InputBankVerification
+import com.example.engu_pension_verification_application.model.input.InputEinNumber
+import com.example.engu_pension_verification_application.model.input.InputLGAList
+import com.example.engu_pension_verification_application.model.input.InputRefreshToken
+import com.example.engu_pension_verification_application.model.input.InputSwiftBankCode
+import com.example.engu_pension_verification_application.model.response.ResponseActiveBasicDetails
+import com.example.engu_pension_verification_application.model.response.ResponseActiveBasicRetrive
+import com.example.engu_pension_verification_application.model.response.ResponseActiveDocRetrive
+import com.example.engu_pension_verification_application.model.response.ResponseActiveDocUpload
+import com.example.engu_pension_verification_application.model.response.ResponseBankInfo
+import com.example.engu_pension_verification_application.model.response.ResponseBankList
+import com.example.engu_pension_verification_application.model.response.ResponseBankVerify
+import com.example.engu_pension_verification_application.model.response.ResponseCombinationDetails
+import com.example.engu_pension_verification_application.model.response.ResponseEinNumber
+import com.example.engu_pension_verification_application.model.response.ResponseRefreshToken
+import com.example.engu_pension_verification_application.model.response.ResponseSwiftBankCode
+import com.example.engu_pension_verification_application.network.ApiInterface
+import com.example.engu_pension_verification_application.utils.ApiUtil
+import okhttp3.RequestBody
+
+class NetworkRepo(private val apiInterface: ApiInterface) {
+    suspend fun fetchBankList(): ResponseBankList {
+//        return ApiUtil.handleResponse(apiInterface.fetchBankList(ApiUtil.getAccessToken()))
+        return apiInterface.getAddedBanks(ApiUtil.getAccessToken())
+    }
+    suspend fun fetchCombinedDetails(inputLGAList: InputLGAList): ResponseCombinationDetails {
+        return apiInterface.getCombinationDetails(inputLGAList)
+    }
+    suspend fun fetchActiveBasicDetails(): ResponseActiveBasicRetrive {
+        return apiInterface.getActiveBasicRetrive(ApiUtil.getAccessToken())
+    }
+    suspend fun uploadAccountDetails(inputActiveBasicDetails: InputActiveBasicDetails): ResponseActiveBasicDetails {
+        return apiInterface.getActiveDetails(ApiUtil.getAccessToken(), inputActiveBasicDetails)
+    }
+    suspend fun fetchActiveDocuments(): ResponseActiveDocRetrive {
+        return apiInterface.getActiveDocRetrive(ApiUtil.getAccessToken())
+    }
+    suspend fun fetchBankDetails(inputSwiftBankCode: InputSwiftBankCode): ResponseSwiftBankCode {
+        return apiInterface.getSwiftBankCode(ApiUtil.getAccessToken(),inputSwiftBankCode)
+    }
+    suspend fun submitBankInfo(inputActiveBankInfo: InputActiveBankInfo): ResponseBankInfo {
+        return apiInterface.getActiveBankInfo(ApiUtil.getAccessToken(),inputActiveBankInfo)
+    }
+    suspend fun verifyBankAccount(inputBankVerification: InputBankVerification): ResponseBankVerify {
+        return apiInterface.getBankVerify(ApiUtil.getAccessToken(),inputBankVerification)
+    }
+    suspend fun submitEin(ein: String): ResponseEinNumber {
+        return apiInterface.getEinNumber(ApiUtil.getAccessToken(), InputEinNumber(ein))
+    }
+    suspend fun fetchRefreshToken(): ResponseRefreshToken {
+        return apiInterface.getRefreshToken(InputRefreshToken(AppConstants.REFRESH_TOKEN))
+    }
+
+    suspend fun uploadActiveDocuments(requestBody: RequestBody): ResponseActiveDocUpload {
+        return apiInterface.upLoadActiveUserDocuments(
+            ApiUtil.getAccessToken(),
+            requestBody
+        )
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/network/ApiClient.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/network/ApiClient.kt
@@ -14,10 +14,19 @@ object ApiClient {
     var prefs = SharedPref
 
     var BASE_URL: String = "https://pension-distributor.demoserver.work"
+    @Volatile private var apiInterface:ApiInterface? =null
 
-
-    fun getRetrofit(): ApiInterface {
-
+    fun getApiInterface(): ApiInterface {
+        if (apiInterface == null) {
+            synchronized(this) {
+                if (apiInterface == null) {
+                    apiInterface = createRetrofit()
+                }
+            }
+        }
+        return apiInterface!!
+    }
+    private fun createRetrofit(): ApiInterface {
         var interceptor = HttpLoggingInterceptor()
         interceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/Dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/Dashboard/DashboardViewModel.kt
@@ -1,13 +1,6 @@
 package com.example.engu_pension_verification_application.ui.fragment.Dashboard
 
-import android.app.Application
 import android.util.Log
-import android.widget.Toast
-import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.commons.Loader
-import com.example.engu_pension_verification_application.model.input.InputRefreshToken
 import com.example.engu_pension_verification_application.model.response.*
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
@@ -48,7 +41,7 @@ Loader.hideLoader()
                 ).show()
             }*/
             try {
-                val response = ApiClient.getRetrofit().getLogout("Bearer " +prefs.access_token.toString()) //"Bearer Token " +
+                val response = ApiClient.getApiInterface().getLogout("Bearer " +prefs.access_token.toString()) //"Bearer Token " +
 
                 if (response.logout_detail?.status.equals("success")) {
                     dashboardCallBack.ondashboardLogoutSuccess(response)
@@ -71,7 +64,7 @@ Loader.hideLoader()
     fun getDashboardDetails() {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getDashBoardDetails("Bearer " +prefs.access_token.toString()) //"Bearer Token " +
+                val response = ApiClient.getApiInterface().getDashBoardDetails("Bearer " +prefs.access_token.toString()) //"Bearer Token " +
 
                 if (response.detail?.status.equals("success")) {
                     dashboardCallBack.ondashboardDetailsSuccess(response)

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/ActiveServicePresenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/ActiveServicePresenter.kt
@@ -16,7 +16,7 @@ class ActiveServicePresenter(var activeServiceViewCallBack: ActiveServiceViewCal
     fun getBankList() {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getAddedBanks(
+                val response = ApiClient.getApiInterface().getAddedBanks(
                     "Bearer " + prefs.access_token.toString()
                 ) //
                 // Log.d("Model", "getBankList: "+response.banks)

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/EIN_Number/EIN_Number_Presenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/EIN_Number/EIN_Number_Presenter.kt
@@ -22,7 +22,7 @@ class EIN_Number_Presenter(var einNumberCallback: EIN_Number_CallBack) {
 
                 Log.d("Inputs", "EinSubmitCall: $inputEinNumber")
                 Log.d("token", "EinSubmitCall: "+ prefs.access_token.toString())
-                val response = ApiClient.getRetrofit().getEinNumber("Bearer " + prefs.access_token.toString(),inputEinNumber)
+                val response = ApiClient.getApiInterface().getEinNumber("Bearer " + prefs.access_token.toString(),inputEinNumber)
                 //_ActiveBankInfoStatus.value = response
 
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/EIN_Number/Retiree_EIN_Number_Presenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/EIN_Number/Retiree_EIN_Number_Presenter.kt
@@ -23,7 +23,7 @@ class Retiree_EIN_Number_Presenter(var retireeinNumberCallback:Retiree_EIN_Numbe
 
                 Log.d("Inputs", "RetireeEinSubmitCall: $inputEinNumber")
                 Log.d("token", "RetireeEinSubmitCall: "+ prefs.access_token.toString())
-                val response = ApiClient.getRetrofit().getEinNumber("Bearer " + prefs.access_token.toString(),inputEinNumber)
+                val response = ApiClient.getApiInterface().getEinNumber("Bearer " + prefs.access_token.toString(),inputEinNumber)
                 //_ActiveBankInfoStatus.value = response
 
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/ProcessingVerify/Processing_Verify_Presenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/ProcessingVerify/Processing_Verify_Presenter.kt
@@ -55,7 +55,7 @@ class Processing_Verify_Presenter(var processingVerifyCallback: Processing_Verif
 
 
             try {
-                val response = ApiClient.getRetrofit().getActiveProcessingVerify(
+                val response = ApiClient.getApiInterface().getActiveProcessingVerify(
                     "Bearer " + prefs.access_token.toString()
                 ) //
                 // Log.d("Model", "getBankList: "+response.banks)

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/RetireeServicePresenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/RetireeServicePresenter.kt
@@ -15,7 +15,7 @@ class RetireeServicePresenter(var retireeServiceViewCallBack: RetireeServiceView
         fun getBankList() {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getAddedBanks(
+                val response = ApiClient.getApiInterface().getAddedBanks(
                     "Bearer " + prefs.access_token.toString())
                 // Log.d("Model", "getBankList: "+response.banks)
                 if (response.detail?.status.equals("success")) {

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBankFragment.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBankFragment.kt
@@ -1,6 +1,5 @@
 package com.example.engu_pension_verification_application.ui.fragment.service.active
 
-import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
@@ -23,26 +22,28 @@ import android.widget.AdapterView
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.lifecycleScope
+import com.example.engu_pension_verification_application.Constants.AppConstants
 import com.example.engu_pension_verification_application.R
 import com.example.engu_pension_verification_application.commons.Loader
+import com.example.engu_pension_verification_application.data.NetworkRepo
 import com.example.engu_pension_verification_application.model.input.InputActiveBankInfo
 import com.example.engu_pension_verification_application.model.input.InputBankVerification
-import com.example.engu_pension_verification_application.model.input.InputEinNumber
-import com.example.engu_pension_verification_application.model.input.InputSwiftBankCode
 import com.example.engu_pension_verification_application.model.response.*
+import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.ui.activity.ProcessDashboardActivity
-import com.example.engu_pension_verification_application.ui.activity.SignUpActivity
-import com.example.engu_pension_verification_application.ui.fragment.service.EIN_Number.EIN_Number_CallBack
-import com.example.engu_pension_verification_application.ui.fragment.service.EIN_Number.EIN_Number_Presenter
 import com.example.engu_pension_verification_application.ui.fragment.service.accounttype.AccountTypeAdapter
 import com.example.engu_pension_verification_application.ui.fragment.service.bank.BankAdapter
-import com.example.engu_pension_verification_application.ui.fragment.service.bank_verification.Bank_Verify_Callback
-import com.example.engu_pension_verification_application.ui.fragment.service.bank_verification.Bank_Verify_Presenter
-import com.example.engu_pension_verification_application.ui.fragment.tokenrefresh.TokenRefreshCallBack
-import com.example.engu_pension_verification_application.ui.fragment.tokenrefresh.TokenRefreshViewModel
 import com.example.engu_pension_verification_application.utils.SharedPref
+import com.example.engu_pension_verification_application.view_models.ActiveBankViewModelFactory
+import com.example.engu_pension_verification_application.view_models.ActiveServiceViewModel
+import com.example.engu_pension_verification_application.view_models.TokenRefreshViewModel2
+import com.example.engu_pension_verification_application.view_models.TokenRefreshViewModel2Factory
 import kotlinx.android.synthetic.main.fragment_active_bank.*
-import kotlinx.android.synthetic.main.fragment_retiree_bank.et_retireebank_swiftcode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 import kotlin.collections.ArrayList
 
@@ -54,10 +55,14 @@ val filterUpperCaseAndDigits = InputFilter { source, start, end, dest, dstart, d
     }
     null // Accepts the original characters
 }
-class ActiveBankFragment(
-    var bankdetailsList: ArrayList<ListBanksItem?>,
-    @JvmField var accountTypeList: ArrayList<AccountTypeItem?>,
-) : Fragment(), TokenRefreshCallBack, ActiveBankCallBack, EIN_Number_CallBack,Bank_Verify_Callback {
+class ActiveBankFragment: Fragment() {
+    companion object {
+        private const val TAB_POSITION = 2
+    }
+    var bankdetailsList = mutableListOf<ListBanksItem?>()
+    var accountTypeList = mutableListOf<AccountTypeItem?>()
+
+    private val activeServiceViewModel by activityViewModels<ActiveServiceViewModel>()
 
     val FULL_NAME_PATTERN =
         Pattern.compile("^[a-zA-Z]+(?:\\s[a-zA-Z]+)*$") /*Pattern.compile("^[a-zA-Z\\s]+$")*/
@@ -66,11 +71,7 @@ class ActiveBankFragment(
     val ACC_NO_PATTERN_TWO = Pattern.compile("\\d{10,12}")
 
     private lateinit var activeBankViewModel: ActiveBankViewModel
-    private lateinit var tokenRefreshViewModel: TokenRefreshViewModel
-
-    private lateinit var einnumberpresenter: EIN_Number_Presenter
-
-    private lateinit var bankVerifyPresenter: Bank_Verify_Presenter
+    private lateinit var tokenRefreshViewModel2: TokenRefreshViewModel2
 
 
     var a_bankid = ""
@@ -98,16 +99,14 @@ class ActiveBankFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initViewModels()
+        observeLiveData()
 
         //activeBankViewModel = ViewModelProvider(this).get(ActiveBankViewModel::class.java)
-        activeBankViewModel = ActiveBankViewModel(this)
 
         /*tokenRefreshViewModel = ViewModelProvider(this).get(TokenRefreshViewModel::class.java)*/
-        tokenRefreshViewModel = TokenRefreshViewModel(this)
 
-        einnumberpresenter = EIN_Number_Presenter(this)
 
-        bankVerifyPresenter = Bank_Verify_Presenter(this)
 
         //local use
 //        et_activebank_swiftcode.text = Editable.Factory.getInstance().newEditable("MOOGNGL1")
@@ -131,7 +130,7 @@ class ActiveBankFragment(
 
 
 
-        setAdapter()
+//        setAdapter()
         // initcall()  - hold
         OnTextWatcher()
         onClicked()
@@ -141,6 +140,127 @@ class ActiveBankFragment(
 
     }
 
+    private fun initViewModels() {
+        val networkRepo = NetworkRepo(ApiClient.getApiInterface())
+        activeBankViewModel = ViewModelProviders.of(
+            this,
+            ActiveBankViewModelFactory(networkRepo)
+        ).get(ActiveBankViewModel::class.java)
+        tokenRefreshViewModel2 = ViewModelProviders.of(
+            requireActivity(), // use `this` if the ViewModel want to tie with fragment's lifecycle
+            TokenRefreshViewModel2Factory(networkRepo)
+        ).get(TokenRefreshViewModel2::class.java)
+    }
+    private fun observeLiveData() {
+        activeServiceViewModel.currentTabPos.observe(viewLifecycleOwner){
+            if (it == TAB_POSITION) activeBankViewModel.fetchBankList()
+        }
+        activeBankViewModel.bankListApiResult.observe(viewLifecycleOwner) { response ->
+            if (response.detail?.status == AppConstants.SUCCESS) {
+                Loader.hideLoader()
+                bankdetailsList.clear()
+                accountTypeList.clear()
+                response.detail.banks?.let {  bankdetailsList.addAll(it)}
+                response.detail.accountType?.let {  accountTypeList.addAll(it)}
+                setAdapter()
+            } else {
+                if (response.detail?.tokenStatus.equals(AppConstants.EXPIRED)) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        if (tokenRefreshViewModel2.fetchRefreshToken()) {
+                            activeBankViewModel.fetchBankList()
+                        }
+                    }
+                } else {
+                    Loader.hideLoader()
+                    Toast.makeText(context, response.detail?.message, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+        activeBankViewModel.bankDetailsApiResult.observe(viewLifecycleOwner) { pair ->
+            val swiftCode = pair.first
+            val response = pair.second
+            if (response.swiftbankdetail?.status == AppConstants.SUCCESS) {
+                Loader.hideLoader()
+                onSwiftBankCodeSuccess(response)
+            } else {
+                if (response.swiftbankdetail?.tokenStatus.equals(AppConstants.EXPIRED)) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        if (tokenRefreshViewModel2.fetchRefreshToken()) {
+                            activeBankViewModel.fetchBankDetails(swiftCode)
+                        }
+                    }
+                } else {
+                    Loader.hideLoader()
+                    Toast.makeText(context, response.swiftbankdetail?.message, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+        activeBankViewModel.bankInfoSubmissionResult.observe(viewLifecycleOwner) { pair ->
+            val inputActiveBankInfo = pair.first
+            val response = pair.second
+            if (response.detail?.status == AppConstants.SUCCESS) {
+                Loader.hideLoader()
+                onActiveBankInfoSubmitSuccess(response)
+            }else if (response.detail?.status == AppConstants.FAIL) {
+                Loader.hideLoader()
+                Toast.makeText(context, response.detail.message, Toast.LENGTH_LONG).show()
+            } else {
+                if (response.detail?.tokenStatus.equals(AppConstants.EXPIRED)) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        if (tokenRefreshViewModel2.fetchRefreshToken()) {
+                            activeBankViewModel.submitBankInfo(inputActiveBankInfo)
+                        }
+                    }
+                } else {
+                    Loader.hideLoader()
+                    Toast.makeText(context, response.detail?.message, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+        activeBankViewModel.bankVerificationResult.observe(viewLifecycleOwner) { pair ->
+            val inputBankVerification = pair.first
+            val response = pair.second
+            if (response.detail?.status == AppConstants.SUCCESS) {
+                Loader.hideLoader()
+                onBankVerifySubmitSuccess(response)
+            } else {
+                if (response.detail?.tokenStatus.equals(AppConstants.EXPIRED)) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        if (tokenRefreshViewModel2.fetchRefreshToken()) {
+                            activeBankViewModel.verifyBankAccount(inputBankVerification)
+                        }
+                    }
+                } else {
+                    Loader.hideLoader()
+                    Toast.makeText(context, response.detail?.message, Toast.LENGTH_LONG).show()
+                    isBankVerifyBtn = false
+                    tv_activebank_bankcode_verify.visibility = View.INVISIBLE
+                    tv_activebank_bankcode_reverify.visibility = View.VISIBLE
+                    tv_activebank_bankcode_verified.visibility = View.INVISIBLE
+
+                }
+            }
+        }
+        activeBankViewModel.einSubmissionResult.observe(viewLifecycleOwner) { pair ->
+            val ein = pair.first
+            val response = pair.second
+            if (response.detail?.status == AppConstants.SUCCESS) {
+                Loader.hideLoader()
+                onEinNumberSubmitSuccess(response)
+            } else {
+                if (response.detail?.tokenStatus.equals(AppConstants.EXPIRED)) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        if (tokenRefreshViewModel2.fetchRefreshToken()) {
+                            activeBankViewModel.submitEin(ein)
+                        }
+                    }
+                } else {
+                    Loader.hideLoader()
+                    Toast.makeText(context, response.detail?.message, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
 
 
     private fun setAdapter() {
@@ -216,7 +336,7 @@ class ActiveBankFragment(
                 et_activebank_swiftcode.setOnFocusChangeListener { view, hasFocus ->
                     if (!hasFocus) {
 
-                        activeBankViewModel.getswiftBankCode(InputSwiftBankCode(swiftCode = et_activebank_swiftcode.text.toString()))
+                        activeBankViewModel.fetchBankDetails(et_activebank_swiftcode.text.toString())
 
                     }
                 }
@@ -350,7 +470,7 @@ class ActiveBankFragment(
         if (TextUtils.isEmpty(et_activebank_accname.text)) {
             Toast.makeText(context, "Empty account Name", Toast.LENGTH_LONG).show()
             return false
-        } else if (!FULL_NAME_PATTERN.matcher(et_activebank_accname.text.toString()).matches()) {
+        } else if (!FULL_NAME_PATTERN.matcher(et_activebank_accname.text.toString().trim()).matches()) {
 
             Toast.makeText(context, "account name not valid", Toast.LENGTH_SHORT).show()
             return false
@@ -385,7 +505,7 @@ class ActiveBankFragment(
     //END Validation Bank info
 
     private fun BankinformationCall() {
-        activeBankViewModel.ActiveBankinformation(
+        activeBankViewModel.submitBankInfo(
             InputActiveBankInfo(
 
                 bankId = a_bankid/*"7b8dc580-ba28-8f3b-354410354410351ab4"*//*sp_active_bank.selectedItemPosition.toString()*/,
@@ -431,52 +551,15 @@ class ActiveBankFragment(
         return connectivityManager?.activeNetworkInfo?.isConnectedOrConnecting() ?: false
     }
 
-    override fun onTokenRefreshSuccess(response: ResponseRefreshToken) {
-        Loader.hideLoader()
-        Toast.makeText(context, "Please wait.....", Toast.LENGTH_SHORT).show()
 
-        //again listing api call
-//                    initcall()
-        BankinformationCall()
-    }
-
-    override fun onTokenRefreshFailure(response: ResponseRefreshToken) {
-        Loader.hideLoader()
-        Toast.makeText(
-            context, response.token_detail?.message, Toast.LENGTH_LONG
-        ).show()
-
-        clearLogin()
-        val intent = Intent(context, SignUpActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        startActivity(intent)
-    }
-
-
-    override fun onSwiftBankCodeSuccess(response: ResponseSwiftBankCode) {
+    fun onSwiftBankCodeSuccess(response: ResponseSwiftBankCode) {
         Loader.hideLoader()
         et_activebank_bankcode.text = Editable.Factory.getInstance()
             .newEditable(response.swiftbankdetail?.swiftCodeResponse?.bankCode)
 
     }
 
-    override fun onSwiftBankCodeFailure(response: ResponseSwiftBankCode) {
-        Loader.hideLoader()
-        if (response.swiftbankdetail?.tokenStatus.equals("expired")) {
-            Toast.makeText(context, "Please wait.....", Toast.LENGTH_SHORT).show()
-            //refresh api call
-            tokenRefreshViewModel.getTokenRefresh()
-            activeBankViewModel.getswiftBankCode(InputSwiftBankCode(swiftCode = et_activebank_swiftcode.text.toString()))
-
-        } else {
-            Toast.makeText(
-                context, response.swiftbankdetail?.message, Toast.LENGTH_LONG
-            ).show()
-        }
-
-    }
-
-    override fun onActiveBankInfoSubmitSuccess(response: ResponseBankInfo) {
+    fun onActiveBankInfoSubmitSuccess(response: ResponseBankInfo) {
 
 
         Loader.hideLoader()
@@ -599,7 +682,7 @@ class ActiveBankFragment(
 
     private fun BankVerifyApiCall(etAccNum: EditText?, etBankCode: EditText?) {
 
-        bankVerifyPresenter.BankVerify_Submit(
+        activeBankViewModel.verifyBankAccount(
             InputBankVerification(
                 accountNumber = etAccNum?.text.toString(),
                 bankCode = etBankCode?.text.toString()
@@ -610,14 +693,7 @@ class ActiveBankFragment(
     }
 
     private fun EinSubmitCall(et_ein_number_popupsub: EditText?) {
-
-        einnumberpresenter.Ein_Number_Submit(
-            InputEinNumber(/* ein = "1234567890"*/
-                ein = et_ein_number_popupsub!!.text.toString()
-
-
-            )
-        )
+        activeBankViewModel.submitEin(et_ein_number_popupsub!!.text.toString())
         Log.d("Ein", "EIN_Number${et_ein_number_popupsub.text}")
     }
 
@@ -682,8 +758,7 @@ class ActiveBankFragment(
         if (TextUtils.isEmpty(et_activebank_accname.text)) {
             Toast.makeText(context, "Empty account Name", Toast.LENGTH_LONG).show()
             return false
-        } else if (!FULL_NAME_PATTERN.matcher(et_activebank_accname.text.toString()).matches()) {
-
+        } else if (!FULL_NAME_PATTERN.matcher(et_activebank_accname.text.toString().trim()).matches()) {
             Toast.makeText(context, "account name not valid", Toast.LENGTH_SHORT).show()
             return false
         }
@@ -703,24 +778,7 @@ class ActiveBankFragment(
     }
 
 
-
-    override fun onActiveBankInfoSubmitFailure(response: ResponseBankInfo) {
-        Loader.hideLoader()
-
-        if (response.detail?.tokenStatus.equals("expired")) {
-            Toast.makeText(context, "Please wait.....", Toast.LENGTH_SHORT).show()
-            //refresh api call
-            tokenRefreshViewModel.getTokenRefresh()
-            BankinformationCall()
-
-        } else {
-            Toast.makeText(
-                context, response.detail?.message, Toast.LENGTH_LONG
-            ).show()
-        }
-    }
-
-    override fun onEinNumberSubmitSuccess(response: ResponseEinNumber) {
+    fun onEinNumberSubmitSuccess(response: ResponseEinNumber) {
 
         Loader.hideLoader()
         Toast.makeText(context, response.detail?.message, Toast.LENGTH_SHORT).show()
@@ -732,21 +790,7 @@ class ActiveBankFragment(
         activity?.finish()
     }
 
-    override fun onEinNumberSubmitFailure(response: ResponseEinNumber) {
-        Loader.hideLoader()
-        if (response.detail?.tokenStatus.equals("expired")) {
-            Toast.makeText(context, "Please wait.....", Toast.LENGTH_SHORT).show()
-            //refresh api call
-            tokenRefreshViewModel.getTokenRefresh()/*  EinSubmitCall()*/
-
-        } else {
-            Toast.makeText(
-                context, response.detail?.message, Toast.LENGTH_LONG
-            ).show()
-        }
-    }
-
-    override fun onBankVerifySubmitSuccess(response: ResponseBankVerify) {
+    fun onBankVerifySubmitSuccess(response: ResponseBankVerify) {
         Loader.hideLoader()
         Toast.makeText(context, response.detail?.message, Toast.LENGTH_SHORT).show()
 
@@ -756,25 +800,6 @@ class ActiveBankFragment(
         tv_activebank_bankcode_verify.visibility = View.INVISIBLE
         tv_activebank_bankcode_reverify.visibility = View.INVISIBLE
         tv_activebank_bankcode_verified.visibility = View.VISIBLE
-    }
-
-    override fun onBankVerifySubmitFailure(response: ResponseBankVerify) {
-        Loader.hideLoader()
-        if (response.detail?.tokenStatus.equals("expired")) {
-            Toast.makeText(context, "Please wait.....", Toast.LENGTH_SHORT).show()
-            //refresh api call
-            tokenRefreshViewModel.getTokenRefresh()/*  EinSubmitCall()*/
-
-        } else {
-            Toast.makeText(
-                context, response.detail?.message, Toast.LENGTH_LONG
-            ).show()
-        }
-        isBankVerifyBtn = false
-
-        tv_activebank_bankcode_verify.visibility = View.INVISIBLE
-        tv_activebank_bankcode_reverify.visibility = View.VISIBLE
-        tv_activebank_bankcode_verified.visibility = View.INVISIBLE
     }
 }
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBankViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBankViewModel.kt
@@ -1,130 +1,141 @@
 package com.example.engu_pension_verification_application.ui.fragment.service.active
 
-
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.commons.Loader
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.engu_pension_verification_application.data.NetworkRepo
 import com.example.engu_pension_verification_application.model.input.InputActiveBankInfo
+import com.example.engu_pension_verification_application.model.input.InputBankVerification
 import com.example.engu_pension_verification_application.model.input.InputSwiftBankCode
-import com.example.engu_pension_verification_application.model.response.*
-import com.example.engu_pension_verification_application.network.ApiClient
-import com.example.engu_pension_verification_application.utils.SharedPref
+import com.example.engu_pension_verification_application.model.response.BankDetail
+import com.example.engu_pension_verification_application.model.response.BankVerifyDetail
+import com.example.engu_pension_verification_application.model.response.BanksDetail
+import com.example.engu_pension_verification_application.model.response.EinNumberDetail
+import com.example.engu_pension_verification_application.model.response.ResponseBankInfo
+import com.example.engu_pension_verification_application.model.response.ResponseBankList
+import com.example.engu_pension_verification_application.model.response.ResponseBankVerify
+import com.example.engu_pension_verification_application.model.response.ResponseEinNumber
+import com.example.engu_pension_verification_application.model.response.ResponseSwiftBankCode
+import com.example.engu_pension_verification_application.model.response.SwiftBankDetail
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class ActiveBankViewModel(var activeBankCallBack: ActiveBankCallBack){
+class ActiveBankViewModel(private val networkRepo: NetworkRepo) : ViewModel() {
 
-    /*(application: Application) : AndroidViewModel(application)*/
-    private val prefs = SharedPref
+    private val _bankListApiResult = MutableLiveData<ResponseBankList>()
+    val bankListApiResult: LiveData<ResponseBankList>
+        get() = _bankListApiResult
 
-    /*private val _banklistStatus = MutableLiveData<ResponseBankList>()
-    val BanklistStatus: LiveData<ResponseBankList>
-        get() = _banklistStatus
+    private val _bankDetailsApiResult = MutableLiveData<Pair<String, ResponseSwiftBankCode>>()
+    val bankDetailsApiResult: LiveData<Pair<String, ResponseSwiftBankCode>>
+        get() = _bankDetailsApiResult
 
-    private val _SwiftBankCodeStatus = MutableLiveData<ResponseSwiftBankCode>()
-    val SwiftBankCodeStatus: LiveData<ResponseSwiftBankCode>
-        get() = _SwiftBankCodeStatus
+    private val _bankInfoSubmissionResult =
+        MutableLiveData<Pair<InputActiveBankInfo, ResponseBankInfo>>()
+    val bankInfoSubmissionResult: LiveData<Pair<InputActiveBankInfo, ResponseBankInfo>>
+        get() = _bankInfoSubmissionResult
 
-    private val _ActiveBankInfoStatus = MutableLiveData<ResponseBankInfo>()
-    val ActiveBankInfoStatus : LiveData<ResponseBankInfo>
-    get() = _ActiveBankInfoStatus*/
+    private val _bankVerificationResult =
+        MutableLiveData<Pair<InputBankVerification, ResponseBankVerify>>()
+    val bankVerificationResult: LiveData<Pair<InputBankVerification, ResponseBankVerify>>
+        get() = _bankVerificationResult
 
+    private val _einSubmissionResult =
+        MutableLiveData<Pair<String, ResponseEinNumber>>()
+    val einSubmissionResult: LiveData<Pair<String, ResponseEinNumber>>
+        get() = _einSubmissionResult
 
-    /*init {
-        application.let { prefs.with(it) }
-    }*/
-
-    fun ActiveBankinformation(inputActiveBankInfo: InputActiveBankInfo){
-        GlobalScope.launch(Dispatchers.Main){
+    fun fetchBankDetails(swiftCode: String) {
+        viewModelScope.launch(Dispatchers.IO) {
             try {
-
-                Log.d("Inputs", "FinishFnCall: "+inputActiveBankInfo)
-                Log.d("token", "FinishFnCall: "+ prefs.access_token.toString())
-                val response = ApiClient.getRetrofit().getActiveBankInfo("Bearer " + prefs.access_token.toString(),inputActiveBankInfo)
-                //_ActiveBankInfoStatus.value = response
-
-
-                if (response!!.detail?.status.equals("success")){
-
-                    activeBankCallBack.onActiveBankInfoSubmitSuccess(response)
-                }
-                else {
-                    activeBankCallBack.onActiveBankInfoSubmitFailure(response)
-                }
-
-            }
-            catch (e : java.lang.Exception){
-                Loader.hideLoader()
-                Log.d("TAG", "ActiveBankinformation: "+e.localizedMessage)
-
-
-                activeBankCallBack.onActiveBankInfoSubmitFailure(
-                    ResponseBankInfo(
-                        BankDetail(message = "Something went wrong in Bank Submit Api")
-                    )
+                _bankDetailsApiResult.postValue(
+                    Pair(swiftCode, networkRepo.fetchBankDetails(InputSwiftBankCode(swiftCode)))
                 )
-
-
-
-
-//                _ActiveBankInfoStatus.value = ResponseActiveBankInfo(ResBankDetail( "Something Went Wrong "))
-            }
-        }
-    }
-
-    /*fun getBankList() {
-        GlobalScope.launch(Dispatchers.Main) {
-            try {
-                val response = ApiClient.getRetrofit().getAddedBanks(
-                    "Bearer " + prefs.access_token.toString()) //
-               // Log.d("Model", "getBankList: "+response.banks)
-                if (response.detail?.status.equals("success")) {
-
-                   // Log.d("Model", "getBankList: "+response.banks)
-                    //_banklistStatus.value = response
-                    activeBankCallBack.onBankListSuccess(response)
-                } else {
-                    //_banklistStatus.value = response
-                    activeBankCallBack.onBankListFailure(response)
-                }
-
-            } catch (e: java.lang.Exception) {
-                Log.d("Model", "getBankList: "+e.localizedMessage)
-//                Log.d("bank_error", "${ResponseBankList(BankDetail())}")
-//
-//                _banklistStatus.value = ResponseBankList(BankDetail(message = "Something went wrong"))
-            }
-        }
-    }*/
-
-    fun getswiftBankCode(inputswiftcode: InputSwiftBankCode) {
-        GlobalScope.launch(Dispatchers.Main) {
-            try {
-                val response = ApiClient.getRetrofit().getSwiftBankCode(
-                    "Bearer " + prefs.access_token.toString(),inputswiftcode )
-
-                if (response.swiftbankdetail?.status.equals("success")) {
-                    // Log.d("Model", "getBankList: "+response.banks)
-                    //_SwiftBankCodeStatus.value = response
-                    activeBankCallBack.onSwiftBankCodeSuccess(response)
-                } else {
-                    activeBankCallBack.onSwiftBankCodeFailure(response)
-                    //_SwiftBankCodeStatus.value = response
-                }
-
-            } catch (e: java.lang.Exception) {
-                Log.d("bank_swift_error", "${ResponseSwiftBankCode(SwiftBankDetail())}")
-//                _SwiftBankCodeStatus.value = ResponseSwiftBankCode(SwiftBankDetail(message = "Something went wrong"))
-
-                activeBankCallBack.onSwiftBankCodeFailure(
-                    ResponseSwiftBankCode(
-                        SwiftBankDetail(message = "Something went wrong in swift Api")
+            } catch (e: Exception) {
+                _bankDetailsApiResult.postValue(
+                    Pair(
+                        swiftCode,
+                        ResponseSwiftBankCode(
+                            SwiftBankDetail(message = "Something went wrong with fetching bank details")
+                        )
                     )
                 )
             }
         }
     }
 
+    fun submitBankInfo(inputActiveBankInfo: InputActiveBankInfo) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _bankInfoSubmissionResult.postValue(
+                    Pair(inputActiveBankInfo, networkRepo.submitBankInfo(inputActiveBankInfo))
+                )
+            } catch (e: Exception) {
+                _bankInfoSubmissionResult.postValue(
+                    Pair(
+                        inputActiveBankInfo,
+                        ResponseBankInfo(
+                            BankDetail(message = "Something went wrong with bank info submission")
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    fun verifyBankAccount(inputBankVerification: InputBankVerification) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _bankVerificationResult.postValue(
+                    Pair(
+                        inputBankVerification,
+                        networkRepo.verifyBankAccount(inputBankVerification)
+                    )
+                )
+            } catch (e: Exception) {
+                _bankVerificationResult.postValue(
+                    Pair(
+                        inputBankVerification,
+                        ResponseBankVerify(
+                            BankVerifyDetail(message = "Something went wrong with bank verification")
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    fun submitEin(ein: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _einSubmissionResult.postValue(
+                    Pair(ein, networkRepo.submitEin(ein))
+                )
+            } catch (e: Exception) {
+                _einSubmissionResult.postValue(
+                    Pair(
+                        ein,
+                        ResponseEinNumber(
+                            EinNumberDetail(message = "Something went wrong with EIN submission")
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    fun fetchBankList() {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _bankListApiResult.postValue(networkRepo.fetchBankList())
+            } catch (e: Exception) {
+                _bankListApiResult.postValue(
+                    ResponseBankList(
+                        BanksDetail(message = "Something went wrong with fetching bank list")
+                    )
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBasicDetailViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveBasicDetailViewModel.kt
@@ -1,6 +1,11 @@
 package com.example.engu_pension_verification_application.ui.fragment.service.active
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.engu_pension_verification_application.data.NetworkRepo
 import com.example.engu_pension_verification_application.model.input.InputActiveBasicDetails
 import com.example.engu_pension_verification_application.model.input.InputLGAList
 import com.example.engu_pension_verification_application.model.response.*
@@ -10,152 +15,66 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class ActiveBasicDetailViewModel(var activeBasicDetailViewCallBack: ActiveBasicDetailViewCallBack) {
-    //(application: Application) : AndroidViewModel(application)
-    private val prefs = SharedPref
+class ActiveBasicDetailViewModel(
+    private val networkRepo: NetworkRepo
+):ViewModel() {
+    private val _combinedDetailsApiResult = MutableLiveData<ResponseCombinationDetails>()
+    val combinedDetailsApiResult: LiveData<ResponseCombinationDetails>
+        get() = _combinedDetailsApiResult
+
+    private val _basicDetailsApiResult = MutableLiveData<ResponseActiveBasicRetrive>()
+    val basicDetailsApiResult: LiveData<ResponseActiveBasicRetrive>
+        get() = _basicDetailsApiResult
+
+    private val _basicDetailsSubmissionResult =
+        MutableLiveData<Pair<InputActiveBasicDetails, ResponseActiveBasicDetails>>()
+    val basicDetailsSubmissionResult: LiveData<Pair<InputActiveBasicDetails, ResponseActiveBasicDetails>>
+        get() = _basicDetailsSubmissionResult
 
 
-    /* private val _combinedDetailstatus = MutableLiveData<ResponseCombinationDetails>()
-     val combinedDetailstatusStatus: LiveData<ResponseCombinationDetails>
-         get() = _combinedDetailstatus
-
-
-     private val _activeBasicDetailstatus = MutableLiveData<ResponseActiveBasicDetails>()
-     val activeBasicDetailsStatus: LiveData<ResponseActiveBasicDetails>
-         get() = _activeBasicDetailstatus
- */
-
-    /*init {
-        application.let { prefs.with(it) }
-    }*/
-
-
-    fun getCombinedDetails(inputLGAList: InputLGAList) {
-        GlobalScope.launch(Dispatchers.Main) {
-            try {
-                val response = ApiClient.getRetrofit().getCombinationDetails(
-                    inputLGAList
-                ) //"Token " +prefs.access_token.toString()) //"Bearer Token "
-                // "Bearer " + prefs.access_token.toString(),
-                Log.d("combineDetail", "$response")
-
-                if (response.combinedetails?.status.equals("success")) {
-                    // _combinedDetailstatus.value = response
-                    activeBasicDetailViewCallBack.onAcombinedDetailSuccess(response)
-                } else {
-                    //_combinedDetailstatus.value = response
-                    activeBasicDetailViewCallBack.onAcombinedDetailFail(response)
-                }
-
-            } catch (e: java.lang.Exception) {
-                activeBasicDetailViewCallBack.onAcombinedDetailFail(
-                    ResponseCombinationDetails(
-                        CombinationDetail(message = "Something went wrong Combination Api")
-                    )
-                )/* _combinedDetailstatus.value =
-                     ResponseCombinationDetails(
-                         CombinationDetail(
-                             message = "Something went wrong"
-                         )
-                     )*/
-            }
+    suspend fun fetchCombinedDetails(country: String): Boolean {
+        try {
+            _combinedDetailsApiResult.postValue(networkRepo.fetchCombinedDetails(InputLGAList(country)))
+            return true
+        } catch (e: Exception) {
+            _combinedDetailsApiResult.postValue(
+                ResponseCombinationDetails(
+                    CombinationDetail(message = "Something went wrong with fetching combined details")
+                )
+            )
         }
-
-        /* GlobalScope.launch(Dispatchers.Main) {
-             try {
-                 val response = ApiClient.getRetrofit().getCombinationDetails(inputLGAList)
-                 if (response.combinedetails?.status!!.equals("success")) {
-                     activeBasicDetailViewCallBack.onActiveBasicCombinedDetailSuccess(response)
-
-                 } else {
-                     activeBasicDetailViewCallBack.onActiveBasicCombinedDetailFailure(response)
-                 }
-             } catch (e: java.lang.Exception) {
-                 Log.d("Exception", "getCombinedDetails: " + e.localizedMessage)
-                 activeBasicDetailViewCallBack.onActiveBasicCombinedDetailFailure(
-                     ResponseCombinationDetails(CombinationDetail(message = "Something went wrong"))
-                 )
-             }
-         }*/
+        return false
     }
 
-    //submission api
-    fun getAccountDetails(inputActiveBasicDetails: InputActiveBasicDetails) {
-        GlobalScope.launch(Dispatchers.Main) {
+    fun fetchActiveBasicDetails() {
+        viewModelScope.launch(Dispatchers.IO) {
             try {
-
-                //"Bearer " + prefs.access_token.toString()
-                val response = ApiClient.getRetrofit().getActiveDetails(
-                    "Bearer " + prefs.access_token.toString(), inputActiveBasicDetails
-                )
-                if (response.detail?.status.equals("success")) {
-                    //_activeBasicDetailstatus.value = response
-                    activeBasicDetailViewCallBack.onActiveBasicDetailSuccess(response)
-
-
-
-                    Log.d("active_basic_response", "${response.detail?.userProfileDetails}")
-                    //Log.d("inputActive", "$inputActiveBasicDetails")
-                } else {
-                    //_activeBasicDetailstatus.value = response
-                    activeBasicDetailViewCallBack.onActiveBasicDetailFailure(response)
-                }
-            } catch (e: java.lang.Exception) {
-
-                Log.e("active_basic_response", "activeBasicFailure", e)
-                activeBasicDetailViewCallBack.onActiveBasicDetailFailure(
-                    ResponseActiveBasicDetails(
-                        ActiveBasicDetail(message = "Something went wrong Active basic submit Api")
-                    )
-                )/*  _activeBasicDetailstatus.value =
-                      ResponseActiveBasicDetails(
-                          ActiveBasicDetail(
-                              message = "Something went wrong"
-                          )
-
-                      )*/
-
-            }
-        }
-    }
-
-    fun getRetriveDetails() {
-        GlobalScope.launch(Dispatchers.Main) {
-            try {
-                val response = ApiClient.getRetrofit().getActiveBasicRetrive(
-                    "Bearer " + prefs.access_token.toString()
-                )
-
-                Log.d("retrive", "Activeretriv" + response)
-
-                /*var s = response.detail?.status
-
-                when(s){
-                    s.equals("success").toString() -> activeBasicDetailViewCallBack.onActiveRetriveSuccess(response)
-                    s.equals("fail").toString() -> activeBasicDetailViewCallBack.onActiveRetriveFailure(response)
-                    else -> {
-
-                        activeBasicDetailViewCallBack.onActiveRetriveFailure(
-                            ResponseActiveRetrive(
-                                ActiveRetriveDetail(message = "Something went wrong in Retrive api")
-                            )
-                        )
-                    }
-                }*/
-
-                if (response.detail?.status.equals("success")) {
-                    activeBasicDetailViewCallBack.onActiveRetriveSuccess(response)
-
-                } else {
-                    activeBasicDetailViewCallBack.onActiveRetriveFailure(response)
-                }
-
-            } catch (e: java.lang.Exception) {
-
-
-                activeBasicDetailViewCallBack.onActiveRetriveFailure(
+                _basicDetailsApiResult.postValue(networkRepo.fetchActiveBasicDetails())
+            } catch (e: Exception) {
+                _basicDetailsApiResult.postValue(
                     ResponseActiveBasicRetrive(
-                        ActiveRetriveDetail(message = "Something went wrong in Active Basic Retrive api")
+                        ActiveRetriveDetail(message = "Something went wrong with fetching basic details")
+                    )
+                )
+            }
+        }
+    }
+
+    fun submitAccountDetails(inputActiveBasicDetails: InputActiveBasicDetails) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _basicDetailsSubmissionResult.postValue(
+                    Pair(
+                        inputActiveBasicDetails,
+                        networkRepo.uploadAccountDetails(inputActiveBasicDetails)
+                    )
+                )
+            } catch (e: Exception) {
+                _basicDetailsSubmissionResult.postValue(
+                    Pair(
+                        inputActiveBasicDetails, ResponseActiveBasicDetails(
+                            ActiveBasicDetail(message = "Something went wrong with fetching basic details submission")
+                        )
                     )
                 )
             }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveDocumentsViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/active/ActiveDocumentsViewModel.kt
@@ -1,10 +1,17 @@
 package com.example.engu_pension_verification_application.ui.fragment.service.active
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.engu_pension_verification_application.data.NetworkRepo
 import com.example.engu_pension_verification_application.model.response.ActiveDocDetail
 import com.example.engu_pension_verification_application.model.response.ActiveDocRetriveDetail
+import com.example.engu_pension_verification_application.model.response.BanksDetail
 import com.example.engu_pension_verification_application.model.response.ResponseActiveDocRetrive
 import com.example.engu_pension_verification_application.model.response.ResponseActiveDocUpload
+import com.example.engu_pension_verification_application.model.response.ResponseBankList
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
 import kotlinx.coroutines.Dispatchers
@@ -12,63 +19,35 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.RequestBody
 
-class ActiveDocumentsViewModel(var activeDocCallBack: ActiveDocCallBack) {
+class ActiveDocumentsViewModel(private val networkRepo: NetworkRepo) :ViewModel()
+{
+    private val _documentsApiResult = MutableLiveData<ResponseActiveDocRetrive>()
+    val documentsApiResult: LiveData<ResponseActiveDocRetrive>
+        get() = _documentsApiResult
 
-    private val prefs = SharedPref
-
-    fun docUpload(requestbody: RequestBody) {
-        GlobalScope.launch(Dispatchers.Main) {
+    private val _documentsUploadResult = MutableLiveData<Pair<RequestBody,ResponseActiveDocUpload>>()
+    val documentsUploadResult: LiveData<Pair<RequestBody,ResponseActiveDocUpload>>
+        get() = _documentsUploadResult
+    fun uploadDocuments(requestBody: RequestBody) {
+        viewModelScope.launch (Dispatchers.IO){
             try {
-
-                val response = ApiClient.getRetrofit().upLoadActiveUserDocuments(
-                    "Bearer " + prefs.access_token.toString(),requestbody)
-
-                if (response.detail?.status.equals("success")){
-
-                    activeDocCallBack.onDocUploadSuccess(response)
-
-                }
-                else{
-                    activeDocCallBack.onDocUploadFailure(response)
-
-                }
-            }
-            catch (e : java.lang.Exception){
-                Log.e("Exception", "docUpload: "+e.localizedMessage )
-                activeDocCallBack.onDocUploadFailure( ResponseActiveDocUpload(ActiveDocDetail( message = "Something went wrong in Doc submit")))
-
-            }
-        }
-    }
-
-    fun docRetrive(){
-        GlobalScope.launch(Dispatchers.Main){
-            try {
-                val response = ApiClient.getRetrofit().getActiveDocRetrive(
-                    "Bearer " + prefs.access_token.toString()
+                _documentsUploadResult.postValue(
+                    Pair(requestBody,networkRepo.uploadActiveDocuments(requestBody))
                 )
-
-                Log.d("DocRetrive", "DocRetrive : $response")
-
-                if (response.detail?.status.equals("success")){
-                    activeDocCallBack.onDocRetriveSuccess(response)
-                }
-                else{
-                    activeDocCallBack.onDocRetriveFailure(response)
-                }
-
-            }
-            catch (e: java.lang.Exception){
-
-                activeDocCallBack.onDocRetriveFailure(ResponseActiveDocRetrive(
-                    ActiveDocRetriveDetail(message = "Something went wrong in doc Retrive api")
-                ))
-
+            }catch (e:Exception){
+                _documentsUploadResult.postValue(
+                    Pair(requestBody,ResponseActiveDocUpload(ActiveDocDetail( message = "Something went wrong with documents submission")))
+                )
             }
         }
-
     }
-
-
-
+    fun fetchActiveDocuments(f:Int)  {
+        viewModelScope.launch (Dispatchers.IO){
+            try {
+                _documentsApiResult.postValue(networkRepo.fetchActiveDocuments())
+            } catch (e: Exception) {
+                _documentsApiResult.postValue(ResponseActiveDocRetrive(ActiveDocRetriveDetail(message = "Something went wrong with fetching document")))
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/bank_verification/Bank_Verify_Presenter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/bank_verification/Bank_Verify_Presenter.kt
@@ -3,19 +3,13 @@ package com.example.engu_pension_verification_application.ui.fragment.service.ba
 import android.util.Log
 import com.example.engu_pension_verification_application.commons.Loader
 import com.example.engu_pension_verification_application.model.input.InputBankVerification
-import com.example.engu_pension_verification_application.model.input.InputEinNumber
 import com.example.engu_pension_verification_application.model.response.BankVerifyDetail
-import com.example.engu_pension_verification_application.model.response.Detail
-import com.example.engu_pension_verification_application.model.response.EinNumberDetail
 import com.example.engu_pension_verification_application.model.response.ResponseBankVerify
-import com.example.engu_pension_verification_application.model.response.ResponseEinNumber
 import com.example.engu_pension_verification_application.network.ApiClient
-import com.example.engu_pension_verification_application.ui.fragment.service.EIN_Number.EIN_Number_CallBack
 import com.example.engu_pension_verification_application.utils.SharedPref
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import retrofit2.http.Query
 
 class Bank_Verify_Presenter(var bankVerifyCallback: Bank_Verify_Callback) {
 
@@ -28,7 +22,7 @@ class Bank_Verify_Presenter(var bankVerifyCallback: Bank_Verify_Callback) {
 
                 Log.d("Inputs", "bankverifycall: $inputBankVerification")
                 Log.d("token", "bankverifycall: "+ prefs.access_token.toString())
-                val response = ApiClient.getRetrofit().getBankVerify("Bearer " + prefs.access_token.toString(), inputBankVerification)
+                val response = ApiClient.getApiInterface().getBankVerify("Bearer " + prefs.access_token.toString(), inputBankVerification)
                 //_ActiveBankInfoStatus.value = response
 
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/gradelevel/GradeLevelAdapter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/gradelevel/GradeLevelAdapter.kt
@@ -11,10 +11,19 @@ import com.example.engu_pension_verification_application.model.response.GradeLev
 import com.example.engu_pension_verification_application.ui.fragment.service.subtresury.SubTreasuryAdapter
 import java.util.ArrayList
 
-class GradeLevelAdapter(var context: Context?,var GradeLevelsList: ArrayList<GradeLevelsItem?>) :
+class GradeLevelAdapter(var context: Context?,list: ArrayList<GradeLevelsItem?>) :
     BaseAdapter() {
+    private val GradeLevelsList = ArrayList<GradeLevelsItem?>()
+    init {
+        this.GradeLevelsList.addAll(list)
+    }
     val mInflater: LayoutInflater = LayoutInflater.from(context)
 
+    fun changeList(list: ArrayList<GradeLevelsItem?>) {
+        this.GradeLevelsList.clear()
+        this.GradeLevelsList.addAll(list)
+        notifyDataSetChanged()
+    }
 
     fun getPositionByName(name: String): Int {
         return GradeLevelsList.indexOfFirst { it?.level == name }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/lga/LGASpinnerAdapter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/lga/LGASpinnerAdapter.kt
@@ -11,8 +11,18 @@ import com.example.engu_pension_verification_application.model.response.LgasItem
 import com.example.engu_pension_verification_application.utils.SharedPref
 import java.util.ArrayList
 
-class LGASpinnerAdapter(var context: Context?,var LGAList: ArrayList<LgasItem?>) : BaseAdapter() {
+class LGASpinnerAdapter(var context: Context?,list: ArrayList<LgasItem?>) : BaseAdapter() {
+    private val LGAList = ArrayList<LgasItem?>()
+    init {
+        this.LGAList.addAll(list)
+    }
     val mInflater: LayoutInflater = LayoutInflater.from(context)
+
+    fun changeList(LGAList: ArrayList<LgasItem?>) {
+        this.LGAList.clear()
+        this.LGAList.addAll(LGAList)
+        notifyDataSetChanged()
+    }
 
     fun getPositionByName(name: String): Int {
         return LGAList.indexOfFirst { it?.name == name }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/occupation/occupationsAdapter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/occupation/occupationsAdapter.kt
@@ -10,9 +10,19 @@ import com.example.engu_pension_verification_application.R
 import com.example.engu_pension_verification_application.model.response.OccupationsItem
 import java.util.ArrayList
 
-class OccupationsAdapter(var context: Context?, var occupationsList: ArrayList<OccupationsItem?>) :
+class OccupationsAdapter(var context: Context?, list: ArrayList<OccupationsItem?>) :
     BaseAdapter() {
+        private val occupationsList = ArrayList<OccupationsItem?>()
+    init {
+        this.occupationsList.addAll(list)
+    }
     val mInflater: LayoutInflater = LayoutInflater.from(context)
+
+    fun changeList(occupationsList: ArrayList<OccupationsItem?>) {
+        this.occupationsList.clear()
+        this.occupationsList.addAll(occupationsList)
+        notifyDataSetChanged()
+    }
 
     fun getPositionByName(name: String): Int {
         return occupationsList.indexOfFirst { it?.name == name }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeBankViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeBankViewModel.kt
@@ -36,7 +36,7 @@ class RetireeBankViewModel(var retireeBankCallBack: RetireeBankFragment) {
 
                 Log.d("Inputs", "FinishFnCall: " + inputActiveBankInfo)
                 Log.d("token", "FinishFnCall: " + prefs.access_token.toString())
-                val response = ApiClient.getRetrofit().getActiveBankInfo(
+                val response = ApiClient.getApiInterface().getActiveBankInfo(
                     "Bearer " + prefs.access_token.toString(),
                     inputActiveBankInfo
                 )
@@ -87,7 +87,7 @@ class RetireeBankViewModel(var retireeBankCallBack: RetireeBankFragment) {
     fun getswiftBankCode(inputswiftcode: InputSwiftBankCode) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getSwiftBankCode(
+                val response = ApiClient.getApiInterface().getSwiftBankCode(
                     "Bearer " + prefs.access_token.toString(), inputswiftcode
                 )
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeBasicDetailsViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeBasicDetailsViewModel.kt
@@ -33,7 +33,7 @@ class RetireeBasicDetailsViewModel(var retireeBasicDetailsViewCallBack: RetireeB
     fun getCombinedDetails(inputLGAList: InputLGAList) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getCombinationDetails(
+                val response = ApiClient.getApiInterface().getCombinationDetails(
                     inputLGAList
                 ) //"Token " +prefs.access_token.toString()) //"Bearer Token "
                 // "Bearer " + prefs.access_token.toString(),
@@ -65,7 +65,7 @@ class RetireeBasicDetailsViewModel(var retireeBasicDetailsViewCallBack: RetireeB
     fun getAccountDetails(inputRetireeBasicDetails: InputRetireeBasicDetails) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getRetireeDetails(
+                val response = ApiClient.getApiInterface().getRetireeDetails(
                     "Bearer " + prefs.access_token.toString(), inputRetireeBasicDetails
                 )
                 if (response.detail?.status.equals("success")) {
@@ -105,7 +105,7 @@ class RetireeBasicDetailsViewModel(var retireeBasicDetailsViewCallBack: RetireeB
 
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getRetireeBasicRetrive(
+                val response = ApiClient.getApiInterface().getRetireeBasicRetrive(
                     "Bearer " + prefs.access_token.toString()
                 )
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeDocumentsViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/retiree/RetireeDocumentsViewModel.kt
@@ -22,7 +22,7 @@ class RetireeDocumentsViewModel(var retireeDocCallBack: RetireeDocCallBack) {
             try {
 
 
-                val response = ApiClient.getRetrofit().upLoadRetireeeUserDocuments(
+                val response = ApiClient.getApiInterface().upLoadRetireeeUserDocuments(
                     "Bearer " + prefs.access_token.toString(),requestbody)
 
                 Log.d("DocSubmitRes", "DocSubmitRes : $response")
@@ -49,7 +49,7 @@ class RetireeDocumentsViewModel(var retireeDocCallBack: RetireeDocCallBack) {
     fun retireedocRetrive(){
         GlobalScope.launch(Dispatchers.Main){
             try {
-                val response = ApiClient.getRetrofit().getRetireeDocRetrive(
+                val response = ApiClient.getApiInterface().getRetireeDocRetrive(
                     "Bearer " + prefs.access_token.toString()
                 )
 

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/subtresury/SubTreasuryAdapter.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/service/subtresury/SubTreasuryAdapter.kt
@@ -11,11 +11,19 @@ import com.example.engu_pension_verification_application.model.response.SubTreas
 import com.example.engu_pension_verification_application.ui.fragment.service.lga.LGASpinnerAdapter
 import java.util.ArrayList
 
-class SubTreasuryAdapter(var context: Context?, var subtreasuryList: ArrayList<com.example.engu_pension_verification_application.model.response.SubTreasuryItem?>) :
+class SubTreasuryAdapter(var context: Context?,list: ArrayList<SubTreasuryItem?>) :
     BaseAdapter() {
-
+    private var subtreasuryList = ArrayList<SubTreasuryItem?>()
+    init {
+        this.subtreasuryList.addAll(list)
+    }
     val mInflater: LayoutInflater = LayoutInflater.from(context)
 
+    fun changeList(subtreasuryList: ArrayList<SubTreasuryItem?>) {
+        this.subtreasuryList.clear()
+        this.subtreasuryList.addAll(subtreasuryList)
+        notifyDataSetChanged()
+    }
 
     fun getPositionByName(name: String): Int {
         return subtreasuryList.indexOfFirst { it?.name == name }

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/forgotpassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/forgotpassword/ForgotPasswordViewModel.kt
@@ -1,14 +1,7 @@
 package com.example.engu_pension_verification_application.ui.fragment.signup.forgotpassword
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.model.input.InputForgotPassword
-import com.example.engu_pension_verification_application.model.response.ForgotPasswordDetail
-import com.example.engu_pension_verification_application.model.response.LoginDetail
-import com.example.engu_pension_verification_application.model.response.ResponseForgotPassword
-import com.example.engu_pension_verification_application.model.response.ResponseLogin
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
 import kotlinx.coroutines.Dispatchers
@@ -30,7 +23,7 @@ class ForgotPasswordViewModel(var forgotPassViewCallBack: ForgotPassViewCallBack
     fun doForgotPass(inputForgotPassword: com.example.engu_pension_verification_application.model.input.InputForgotPassword) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getForgotPassword(inputForgotPassword)
+                val response = ApiClient.getApiInterface().getForgotPassword(inputForgotPassword)
 
                 if (response.forgot_detail?.status.equals("success")) {
                     //_ForgotPassStatus.value = response

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/login/LoginViewModel.kt
@@ -1,14 +1,7 @@
 package com.example.engu_pension_verification_application.ui.fragment.signup.login
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.model.input.InputLogin
-import com.example.engu_pension_verification_application.model.response.Detail
-import com.example.engu_pension_verification_application.model.response.LoginDetail
-import com.example.engu_pension_verification_application.model.response.ResponseLogin
-import com.example.engu_pension_verification_application.model.response.SignupResponse
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +24,7 @@ class LoginViewModel(var loginViewCallBack: LoginViewCallBack){
     fun doLogin(inputLogin: com.example.engu_pension_verification_application.model.input.InputLogin) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getLogin(inputLogin)
+                val response = ApiClient.getApiInterface().getLogin(inputLogin)
 
                 if (response.login_detail?.status.equals("success")) {
                     prefs.isLogin = true

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/otp_verify/OTPViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/otp_verify/OTPViewModel.kt
@@ -34,7 +34,7 @@ class OTPViewModel(var otpViewCallBack: OtpViewCallBack) {
     fun doVerifyReg(inputSignupVerify: com.example.engu_pension_verification_application.model.input.InputSignupVerify) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getVerifyRegistrationOTP(inputSignupVerify)
+                val response = ApiClient.getApiInterface().getVerifyRegistrationOTP(inputSignupVerify)
                 //_verificationStatus.value = response
                 if (response.detail?.status.equals("success")) {
                     prefs.isLogin = true
@@ -67,7 +67,7 @@ class OTPViewModel(var otpViewCallBack: OtpViewCallBack) {
     fun doVerifyForgot(inputForgotVerify: InputForgotVerify) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getVerifyForgotOTP(inputForgotVerify)
+                val response = ApiClient.getApiInterface().getVerifyForgotOTP(inputForgotVerify)
                 //_verificationStatus.value = response
                 if (response.detail?.status.equals("success")) {
                     prefs.isLogin = true
@@ -97,7 +97,7 @@ class OTPViewModel(var otpViewCallBack: OtpViewCallBack) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
                // Log.d("TAG _ 2", "onClicked: " + inputResendotp)
-                val response = ApiClient.getRetrofit().getResendOTP(inputResendotp)
+                val response = ApiClient.getApiInterface().getResendOTP(inputResendotp)
                 //Log.d("TAG _ 2.1", "onClicked: " + response.detail?.message)
 
                  if (response.detail?.status.equals("success")) {

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/resetpassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/resetpassword/ResetPasswordViewModel.kt
@@ -1,14 +1,7 @@
 package com.example.engu_pension_verification_application.ui.fragment.signup.resetpassword
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.model.input.InputResetPassword
-import com.example.engu_pension_verification_application.model.response.ForgotPasswordDetail
-import com.example.engu_pension_verification_application.model.response.ResetDetail
-import com.example.engu_pension_verification_application.model.response.ResponseForgotPassword
-import com.example.engu_pension_verification_application.model.response.ResponseResetPassword
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +21,7 @@ class ResetPasswordViewModel(var resetPassCallBack: ResetPassCallBack) {
     fun doReset(inputResetPassword: com.example.engu_pension_verification_application.model.input.InputResetPassword) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getResetPassword(inputResetPassword)
+                val response = ApiClient.getApiInterface().getResetPassword(inputResetPassword)
 
                 if (response.reset_detail?.status.equals("success")) {
                     //_ResetPassStatus.value = response

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/signup/sign_up/SignUpViewModel.kt
@@ -1,20 +1,10 @@
 package com.example.engu_pension_verification_application.ui.fragment.signup.sign_up
 
-import android.app.Application
-import android.graphics.Bitmap
-import android.net.Uri
-import android.util.Log
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.engu_pension_verification_application.model.input.InputSignup
-import com.example.engu_pension_verification_application.model.response.Detail
-import com.example.engu_pension_verification_application.model.response.SignupResponse
 import com.example.engu_pension_verification_application.network.ApiClient
 import com.example.engu_pension_verification_application.utils.SharedPref
-import com.google.gson.Gson
 import kotlinx.coroutines.*
-import java.net.URL
 
 class SignUpViewModel(var signUpCallBack: SignUpCallBack) {
     //(application: Application) : AndroidViewModel(application)
@@ -33,7 +23,7 @@ class SignUpViewModel(var signUpCallBack: SignUpCallBack) {
     fun doSignup(inputSignup: com.example.engu_pension_verification_application.model.input.InputSignup) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                val response = ApiClient.getRetrofit().getSignUp(inputSignup)
+                val response = ApiClient.getApiInterface().getSignUp(inputSignup)
 
                 if (response.detail?.status.equals("success")) {
                     //_signupStatus.value = response

--- a/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/tokenrefresh/TokenRefreshViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/ui/fragment/tokenrefresh/TokenRefreshViewModel.kt
@@ -1,7 +1,5 @@
 package com.example.engu_pension_verification_application.ui.fragment.tokenrefresh
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.example.engu_pension_verification_application.model.input.InputRefreshToken
@@ -29,7 +27,7 @@ class TokenRefreshViewModel(var tokenRefreshCallBack: TokenRefreshCallBack) {
         GlobalScope.launch(Dispatchers.Main) {
             try {
                 val response =
-                    ApiClient.getRetrofit().getRefreshToken(
+                    ApiClient.getApiInterface().getRefreshToken(
                         InputRefreshToken(
                             prefs.refresh_token
                         )

--- a/app/src/main/java/com/example/engu_pension_verification_application/utils/ApiUtil.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/utils/ApiUtil.kt
@@ -1,0 +1,25 @@
+package com.example.engu_pension_verification_application.utils
+
+import com.example.engu_pension_verification_application.Constants.AppConstants
+import com.example.engu_pension_verification_application.data.ApiResult
+import retrofit2.Response
+
+object ApiUtil {
+    fun getAccessToken(): String {
+        if (AppConstants.ACCESS_TOKEN.isEmpty())
+            AppConstants.ACCESS_TOKEN = SharedPref.access_token ?: ""
+        return "${AppConstants.BEARER} ${AppConstants.ACCESS_TOKEN}"
+    }
+
+    fun <T> handleResponse(response: Response<T>): ApiResult<T> {
+        return try {
+            if (response.isSuccessful && response.body() != null) {
+                ApiResult.Success(response.body()!!)
+            } else {
+                ApiResult.Error("An error occurred")
+            }
+        } catch (e: Exception) {
+            ApiResult.Error("An error occurred")
+        }
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/utils/SharedPref.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/utils/SharedPref.kt
@@ -2,6 +2,7 @@ package com.example.engu_pension_verification_application.utils
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.example.engu_pension_verification_application.Constants.AppConstants
 
 object SharedPref {
 
@@ -189,11 +190,17 @@ object SharedPref {
 
     var access_token: String?
         get() = sharedPreferences.getString(USER_ACCESS_TOKEN, "")
-        set(value) = sharedPreferences.edit().putString(USER_ACCESS_TOKEN, value).apply()
+        set(value) {
+            AppConstants.ACCESS_TOKEN = value ?: ""
+            sharedPreferences.edit().putString(USER_ACCESS_TOKEN, value).apply()
+        }
 
     var refresh_token: String?
         get() = sharedPreferences.getString(USER_REFRESH_TOKEN, "")
-        set(value) = sharedPreferences.edit().putString(USER_REFRESH_TOKEN, value).apply()
+        set(value)  {
+            AppConstants.REFRESH_TOKEN = value ?: ""
+            sharedPreferences.edit().putString(USER_REFRESH_TOKEN, value).apply()
+        }
 
 
     //active

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveBankViewModelFactory.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveBankViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.example.engu_pension_verification_application.view_models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.engu_pension_verification_application.data.NetworkRepo
+import com.example.engu_pension_verification_application.ui.fragment.service.active.ActiveBankViewModel
+
+class ActiveBankViewModelFactory(private val networkRepo: NetworkRepo) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ActiveBankViewModel::class.java)) {
+            return ActiveBankViewModel(networkRepo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveBasicDetailViewModelFactory.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveBasicDetailViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.example.engu_pension_verification_application.view_models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.engu_pension_verification_application.data.NetworkRepo
+import com.example.engu_pension_verification_application.ui.fragment.service.active.ActiveBasicDetailViewModel
+
+class ActiveBasicDetailViewModelFactory (private val networkRepo: NetworkRepo) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ActiveBasicDetailViewModel::class.java)) {
+            return ActiveBasicDetailViewModel(networkRepo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveDocumentsViewModelFactory.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveDocumentsViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.example.engu_pension_verification_application.view_models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.engu_pension_verification_application.data.NetworkRepo
+import com.example.engu_pension_verification_application.ui.fragment.service.active.ActiveDocumentsViewModel
+
+class ActiveDocumentsViewModelFactory (private val networkRepo: NetworkRepo) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ActiveDocumentsViewModel::class.java)) {
+            return ActiveDocumentsViewModel(networkRepo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveServiceViewModel.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/ActiveServiceViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.engu_pension_verification_application.view_models
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class ActiveServiceViewModel : ViewModel() {
+    private val _onMoveToNextTab = MutableLiveData<Unit>()
+    val onMoveToNextTab : LiveData<Unit>
+        get() = _onMoveToNextTab
+
+    val currentTabPos = MutableLiveData(0)
+
+    val enableTab0 = MutableLiveData(true)
+    val enableTab1 = MutableLiveData(false)
+    val enableTab2 = MutableLiveData(false)
+
+
+    fun setTabsEnabledState(isTab0Enabled: Boolean, isTab1Enabled: Boolean,isTab2Enabled: Boolean) {
+        enableTab0.value = isTab0Enabled
+        enableTab1.value = isTab1Enabled
+        enableTab2.value = isTab2Enabled
+    }
+    fun moveToNextTab() {
+        _onMoveToNextTab.value = Unit
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/TokenRefreshViewModel2.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/TokenRefreshViewModel2.kt
@@ -1,0 +1,54 @@
+package com.example.engu_pension_verification_application.view_models
+
+import android.app.Application
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.engu_pension_verification_application.Constants.AppConstants
+import com.example.engu_pension_verification_application.commons.Loader
+import com.example.engu_pension_verification_application.data.ApiResult
+import com.example.engu_pension_verification_application.data.NetworkRepo
+import com.example.engu_pension_verification_application.model.input.InputRefreshToken
+import com.example.engu_pension_verification_application.model.response.AccountTypeItem
+import com.example.engu_pension_verification_application.model.response.BanksDetail
+import com.example.engu_pension_verification_application.model.response.ListBanksItem
+import com.example.engu_pension_verification_application.model.response.ResponseBankList
+import com.example.engu_pension_verification_application.model.response.ResponseRefreshToken
+import com.example.engu_pension_verification_application.model.response.TokenDetail
+import com.example.engu_pension_verification_application.network.ApiClient
+import com.example.engu_pension_verification_application.ui.activity.SignUpActivity
+import com.example.engu_pension_verification_application.utils.SharedPref
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class TokenRefreshViewModel2(private val networkRepo: NetworkRepo) : ViewModel() {
+
+    private val _tokenRefreshError = MutableLiveData<String?>(null)
+    val tokenRefreshError: LiveData<String?>
+        get() = _tokenRefreshError
+
+    suspend fun fetchRefreshToken(): Boolean {
+        try {
+            val response = networkRepo.fetchRefreshToken()
+            if (response.token_detail?.status == AppConstants.SUCCESS) {
+                SharedPref.access_token = response.token_detail.access
+                SharedPref.refresh_token = response.token_detail.refresh
+                return true
+            } else {
+                _tokenRefreshError.postValue(null)
+                _tokenRefreshError.postValue(response.token_detail?.message ?: "")
+            }
+        } catch (e: Exception) {
+            _tokenRefreshError.postValue(null)
+            _tokenRefreshError.postValue("")
+        }
+        return false
+    }
+}

--- a/app/src/main/java/com/example/engu_pension_verification_application/view_models/TokenRefreshViewModel2Factory.kt
+++ b/app/src/main/java/com/example/engu_pension_verification_application/view_models/TokenRefreshViewModel2Factory.kt
@@ -1,0 +1,15 @@
+package com.example.engu_pension_verification_application.view_models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.engu_pension_verification_application.data.NetworkRepo
+
+class TokenRefreshViewModel2Factory (private val networkRepo: NetworkRepo) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TokenRefreshViewModel2::class.java)) {
+            return TokenRefreshViewModel2(networkRepo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,4 +136,5 @@
     <string name="bank_account_verification">Bank Account Verification</string>
     <string name="reverfy">REVERIFY</string>
     <string name="verified">VERIFIED</string>
+    <string name="common_error_msg">Something went wrong</string>
 </resources>


### PR DESCRIPTION
 - Use a shared ViewModel for all Active Service tabs.
 - Reduce API calls and optimize logic for efficiency.
 - Introduce TokenRefreshViewModel2 to fetch refresh token and observe token refresh error only from the parent fragment ActiveServiceFragment
 - Centralize network communication in NetworkRepo.
 - Fix improper ViewModel & Fragment initializations.
 - Ensure single OkHttpClient instance in ApiClient.